### PR TITLE
chrome74で画像が縦長になる問題を対策

### DIFF
--- a/templates/entry/index.html
+++ b/templates/entry/index.html
@@ -14,11 +14,11 @@ $(function () {
 {% for entry in entry_list %}
 <div class="row p-4 text-left" id="{{ entry.userid }}">
     <div class ="col-md-4 offset-md-4">
-    <div class="card">
+    <div class="card d-block">
         <ul class="list-group list-group-flush">
             <li class="list-group-item">{{ entry.username }}</li>
         </ul>
-        <img class="card-img h-100" src="{{ entry.picture }}">
+        <img class="card-img" src="{{ entry.picture }}">
         <div class="card-body">
         {% if 'userid' in request.session %}
         {% if entry.userid == request.session.userid %}


### PR DESCRIPTION
chrome74で参加表明の画像が縦長になる問題を修正